### PR TITLE
refactor: replace unsafe pointer arithmetic with struct-based serialization

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -1,14 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
-	"unsafe"
+	"io"
 )
 
-// TODO: Use proper go structs with serialization instead of byte arrays and unsafe
-
 // NodeType represents the type of a B-tree node.
-// It can be either an internal node or a leaf node.
 type NodeType uint8
 
 const (
@@ -16,213 +15,201 @@ const (
 	NodeTypeLeaf
 )
 
-// Common node header Layout used by both internal and leaf nodes.
+// Page and storage constants
 const (
-	NodeTypeSize        = int(unsafe.Sizeof(NodeType(0)))
-	NodeTypeOffset      = 0
-	IsRootSize          = int(unsafe.Sizeof(uint8(0)))
-	IsRootOffset        = NodeTypeOffset + NodeTypeSize
-	ParentPointerSize   = int(unsafe.Sizeof(uint32(0)))
-	ParentPointerOffset = IsRootOffset + IsRootSize
-	CommonHeaderSize    = NodeTypeSize + IsRootSize + ParentPointerSize
+	pageSize      = 4096
+	tableMaxPages = 100
 )
 
-// Leaf node header Layout.
+// Row size constants (must match parser.go)
 const (
-	LeafNodeNumCellsSize   = int(unsafe.Sizeof(uint32(0)))
-	LeafNodeNumCellsOffset = CommonHeaderSize
-	LeafNodeNextLeafSize   = int(unsafe.Sizeof(uint32(0)))
-	LeafNodeNextLeafOffset = LeafNodeNumCellsOffset + LeafNodeNumCellsSize
-	LeafNodeHeaderSize     = CommonHeaderSize + LeafNodeNumCellsSize + LeafNodeNextLeafSize
+	rowSize = 4 + ColumnUsernameSize + ColumnEmailSize // 4 (ID) + 32 + 255 = 291
 )
 
-// Leaf node body Layout.
+// LeafNode constants
 const (
-	LeafNodeKeySize       = int(unsafe.Sizeof(uint32(0)))
-	LeafNodeKeyOffset     = 0
-	LeafNodeValueSize     = rowSize
-	LeafNodeValueOffset   = LeafNodeKeyOffset + LeafNodeKeySize
-	LeafNodeCellSize      = LeafNodeKeySize + LeafNodeValueSize
+	// Header: NodeType(1) + IsRoot(1) + Parent(4) + NumCells(4) + NextLeaf(4) = 14 bytes
+	LeafNodeHeaderSize = 14
+	// Cell: Key(4) + Row(291) = 295 bytes
+	LeafNodeCellSize      = 4 + rowSize
 	LeafNodeSpaceForCells = pageSize - LeafNodeHeaderSize
-	LeafNodeMaxCells      = LeafNodeSpaceForCells / LeafNodeCellSize
+	LeafNodeMaxCells      = LeafNodeSpaceForCells / LeafNodeCellSize // 13
 )
 
+// Leaf node split constants
 const (
-	LeafNodeRightSplitCount = (LeafNodeMaxCells + 1) / 2 // +1 is for the new cell we are adding
+	LeafNodeRightSplitCount = (LeafNodeMaxCells + 1) / 2
 	LeafNodeLeftSplitCount  = (LeafNodeMaxCells + 1) - LeafNodeRightSplitCount
 )
 
-// Leaf Node Page Layout
-//
-//   0                   1                   2                   3
-//   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |   NodeType    |    IsRoot     |       ParentPointer           |  bytes 0..5
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                    LeafNodeNumCells (uint32)                  |  bytes 6..9
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                    LeafNodeNextLeaf (uint32)                  |  bytes 10..13
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                        Cell[0]                                |  bytes 14..(14+CellSize-1)
-//  |  Key (u32)  |                Value (rowSize bytes)            |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                        Cell[1]                                |  bytes (14+1*CellSize)..(14+2*CellSize-1)
-//  |  Key (u32)  |                Value (rowSize bytes)            |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                              ...                              |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                        Cell[i]                                |  i in [0..NumCells-1]
-//  |  Key @ (Hdr+i*CellSize) .. (Hdr+i*CellSize+3)                 |
-//  |  Val @ (Hdr+i*CellSize+4) .. (Hdr+(i+1)*CellSize-1)           |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                          Free Space                           |  bytes (Hdr+NumCells*CellSize)..(pageSize-1)
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-// Internal node header layout
+// InternalNode constants
 const (
-	InternalNodeNumKeysSize      = int(unsafe.Sizeof(uint32(0)))
-	InternalNodeNumKeysOffset    = CommonHeaderSize
-	InternalNodeRightChildSize   = int(unsafe.Sizeof(uint32(0)))
-	InternalNodeRightChildOffset = InternalNodeNumKeysOffset + InternalNodeNumKeysSize
-	InternalNodeHeaderSize       = CommonHeaderSize + InternalNodeNumKeysSize + InternalNodeRightChildSize
-)
-
-// Internal node body layout
-const (
-	InternalNodeKeySize   = int(unsafe.Sizeof(uint32(0)))
-	InternalNodeChildSize = int(unsafe.Sizeof(uint32(0)))
-	InternalNodeCellSize  = InternalNodeKeySize + InternalNodeChildSize
-	InternalNodeMaxKeys   = 3
+	// Header: NodeType(1) + IsRoot(1) + Parent(4) + NumKeys(4) + RightChild(4) = 14 bytes
+	InternalNodeHeaderSize = 14
+	// Cell: Child(4) + Key(4) = 8 bytes
+	InternalNodeCellSize = 8
+	InternalNodeMaxKeys  = 3
 )
 
 // Internal node split constants
-// When splitting an internal node with InternalNodeMaxKeys keys, we need to
-// redistribute (InternalNodeMaxKeys + 1) keys (including the new one being inserted).
-// The middle key goes up to the parent, and the rest are split between left and right.
 const (
-	InternalNodeRightSplitCount = (InternalNodeMaxKeys + 1) / 2                               // Keys that go to right node
-	InternalNodeLeftSplitCount  = (InternalNodeMaxKeys + 1) - InternalNodeRightSplitCount - 1 // Keys that stay in left node (-1 for key promoted to parent)
+	InternalNodeRightSplitCount = (InternalNodeMaxKeys + 1) / 2
+	InternalNodeLeftSplitCount  = (InternalNodeMaxKeys + 1) - InternalNodeRightSplitCount - 1
 )
 
-// Internal Node Layout
-//
-// Internal nodes store keys and child pointers that guide tree traversal.
-// Each cell in the body consists of a (child_pointer, key) pair.
-// The header also contains an additional "right child" pointer,
-// making a total of (num_keys + 1) child pointers per internal node.
-//
-// Internal Node Page Layout:
-//
-//   0                   1                   2                   3
-//   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |   NodeType    |    IsRoot     |       ParentPointer           |  bytes 0..5
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                    InternalNodeNumKeys (uint32)               |  bytes 6..9
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                    InternalNodeRightChild (uint32)            |  bytes 10..13
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                           Cell[0]                             |  bytes Hdr..(Hdr+CellSize-1)
-//  |  Child (u32) |                    Key (u32)                   |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                           Cell[1]                             |  bytes (Hdr+1*CellSize)..(Hdr+2*CellSize-1)
-//  |  Child (u32) |                    Key (u32)                   |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                              ...                              |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                           Cell[i]                             |  i in [0..NumKeys-1]
-//  |  Ch @ (Hdr+i*CellSize) .. (Hdr+i*CellSize+3)                  |
-//  |  Ky @ (Hdr+i*CellSize+4) .. (Hdr+(i+1)*CellSize-1)            |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                          Free Space                           |  bytes (Hdr+NumKeys*CellSize)..(pageSize-1)
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-// Leaf node helper functions
-
-func leafNodeNumCells(node []byte) *uint32 {
-	return (*uint32)(unsafe.Pointer(&node[LeafNodeNumCellsOffset]))
-}
-func leafNodeCell(node []byte, cellNum uint32) []byte {
-	start := LeafNodeHeaderSize + int(cellNum)*LeafNodeCellSize
-	end := start + LeafNodeCellSize
-	return node[start:end]
-}
-func leafNodeKey(node []byte, cellNum uint32) *uint32 {
-	cell := leafNodeCell(node, cellNum)
-	return (*uint32)(unsafe.Pointer(&cell[LeafNodeKeyOffset]))
-}
-func leafNodeValue(node []byte, cellNum uint32) []byte {
-	cell := leafNodeCell(node, cellNum)
-	return cell[LeafNodeValueOffset : LeafNodeValueOffset+LeafNodeValueSize]
-}
-func initializeLeafNode(node []byte) {
-	*nodeType(node) = NodeTypeLeaf
-	setNodeRoot(node, false)
-	*leafNodeNumCells(node) = 0
-	*leafNodeNextLeaf(node) = 0 // 0 means no sibling
+// LeafCell represents a cell in a leaf node
+type LeafCell struct {
+	Key   uint32
+	Value Row
 }
 
-func nodeType(node []byte) *NodeType {
-	return (*NodeType)(unsafe.Pointer(&node[NodeTypeOffset]))
+// LeafNode represents a leaf node in the B-tree
+type LeafNode struct {
+	NodeType uint8
+	IsRoot   uint8
+	Parent   uint32
+	NumCells uint32
+	NextLeaf uint32
+	Cells    [LeafNodeMaxCells]LeafCell
 }
 
-func isNodeRoot(node []byte) bool {
-	return node[IsRootOffset] != 0
+// InternalCell represents a cell in an internal node
+type InternalCell struct {
+	Child uint32
+	Key   uint32
 }
 
-func setNodeRoot(node []byte, isRoot bool) {
+// InternalNode represents an internal node in the B-tree
+type InternalNode struct {
+	NodeType   uint8
+	IsRoot     uint8
+	Parent     uint32
+	NumKeys    uint32
+	RightChild uint32
+	Cells      [InternalNodeMaxKeys]InternalCell
+}
+
+// Serialize writes the LeafNode to a byte slice (page)
+func (n *LeafNode) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.LittleEndian, n); err != nil {
+		return nil, err
+	}
+	// Pad to page size
+	page := make([]byte, pageSize)
+	copy(page, buf.Bytes())
+	return page, nil
+}
+
+// Deserialize reads a LeafNode from a byte slice (page)
+func (n *LeafNode) Deserialize(page []byte) error {
+	buf := bytes.NewReader(page)
+	return binary.Read(buf, binary.LittleEndian, n)
+}
+
+// Serialize writes the InternalNode to a byte slice (page)
+func (n *InternalNode) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.LittleEndian, n); err != nil {
+		return nil, err
+	}
+	// Pad to page size
+	page := make([]byte, pageSize)
+	copy(page, buf.Bytes())
+	return page, nil
+}
+
+// Deserialize reads an InternalNode from a byte slice (page)
+func (n *InternalNode) Deserialize(page []byte) error {
+	buf := bytes.NewReader(page)
+	return binary.Read(buf, binary.LittleEndian, n)
+}
+
+// Helper functions for creating and initializing nodes
+
+// NewLeafNode creates a new initialized leaf node
+func NewLeafNode() *LeafNode {
+	return &LeafNode{
+		NodeType: uint8(NodeTypeLeaf),
+		IsRoot:   0,
+		Parent:   0,
+		NumCells: 0,
+		NextLeaf: 0,
+	}
+}
+
+// NewInternalNode creates a new initialized internal node
+func NewInternalNode() *InternalNode {
+	return &InternalNode{
+		NodeType:   uint8(NodeTypeInternal),
+		IsRoot:     0,
+		Parent:     0,
+		NumKeys:    0,
+		RightChild: 0,
+	}
+}
+
+// SetRoot sets the IsRoot flag on the node
+func (n *LeafNode) SetRoot(isRoot bool) {
 	if isRoot {
-		node[IsRootOffset] = 1
+		n.IsRoot = 1
 	} else {
-		node[IsRootOffset] = 0
+		n.IsRoot = 0
 	}
 }
 
-func leafNodeNextLeaf(node []byte) *uint32 {
-	return (*uint32)(unsafe.Pointer(&node[LeafNodeNextLeafOffset]))
-}
-
-// Internal node helper functions
-
-func internalNodeNumKeys(node []byte) *uint32 {
-	return (*uint32)(unsafe.Pointer(&node[InternalNodeNumKeysOffset]))
-}
-
-func internalNodeRightChild(node []byte) *uint32 {
-	return (*uint32)(unsafe.Pointer(&node[InternalNodeRightChildOffset]))
-}
-
-func internalNodeCell(node []byte, cellNum uint32) []byte {
-	start := InternalNodeHeaderSize + int(cellNum)*InternalNodeCellSize
-	end := start + InternalNodeCellSize
-	return node[start:end]
-}
-
-func internalNodeKey(node []byte, cellNum uint32) *uint32 {
-	offset := InternalNodeHeaderSize + int(cellNum)*InternalNodeCellSize + InternalNodeChildSize
-	return (*uint32)(unsafe.Pointer(&node[offset]))
-}
-
-func internalNodeChild(node []byte, cellNum uint32) *uint32 {
-	numKeys := *internalNodeNumKeys(node)
-	if cellNum > numKeys {
-		panic(fmt.Sprintf("Tried to access child_num %d > num_keys %d", cellNum, numKeys))
-	} else if cellNum == numKeys {
-		return internalNodeRightChild(node)
+// SetRoot sets the IsRoot flag on the node
+func (n *InternalNode) SetRoot(isRoot bool) {
+	if isRoot {
+		n.IsRoot = 1
 	} else {
-		cell := internalNodeCell(node, cellNum)
-		return (*uint32)(unsafe.Pointer(&cell[0]))
+		n.IsRoot = 0
 	}
 }
 
-// internalNodeFindChild returns the index of the child pointer which should contain the given key
-func internalNodeFindChild(node []byte, key uint32) uint32 {
+// IsRootNode returns whether the node is a root
+func (n *LeafNode) IsRootNode() bool {
+	return n.IsRoot != 0
+}
+
+// IsRootNode returns whether the node is a root
+func (n *InternalNode) IsRootNode() bool {
+	return n.IsRoot != 0
+}
+
+// GetNodeType returns the node type
+func (n *LeafNode) GetNodeType() NodeType {
+	return NodeType(n.NodeType)
+}
+
+// GetNodeType returns the node type
+func (n *InternalNode) GetNodeType() NodeType {
+	return NodeType(n.NodeType)
+}
+
+// GetMaxKey returns the maximum key in the leaf node
+func (n *LeafNode) GetMaxKey() uint32 {
+	if n.NumCells == 0 {
+		panic("cannot get max key from empty leaf node")
+	}
+	return n.Cells[n.NumCells-1].Key
+}
+
+// GetMaxKey returns the maximum key in the internal node
+func (n *InternalNode) GetMaxKey() uint32 {
+	if n.NumKeys == 0 {
+		panic("cannot get max key from empty internal node")
+	}
+	return n.Cells[n.NumKeys-1].Key
+}
+
+// FindChild returns the index of the child pointer which should contain the given key
+func (n *InternalNode) FindChild(key uint32) uint32 {
 	// Binary search
-	numKeys := *internalNodeNumKeys(node)
-	i, j := uint32(0), numKeys
+	i, j := uint32(0), n.NumKeys
 	for i != j {
 		mid := (i + j) / 2
-		midKey := *internalNodeKey(node, mid)
+		midKey := n.Cells[mid].Key
 		if key < midKey {
 			j = mid
 		} else {
@@ -232,54 +219,109 @@ func internalNodeFindChild(node []byte, key uint32) uint32 {
 	return i
 }
 
-func getNodeMaxKey(node []byte) uint32 {
-	nType := *nodeType(node)
-	if nType == NodeTypeLeaf {
-		numCells := *leafNodeNumCells(node)
-		return *leafNodeKey(node, numCells-1)
-	} else if nType == NodeTypeInternal {
-		numKeys := *internalNodeNumKeys(node)
-		return *internalNodeKey(node, numKeys-1)
+// GetChild returns the child page number at the given index
+// Returns RightChild if index equals NumKeys
+func (n *InternalNode) GetChild(index uint32) uint32 {
+	if index > n.NumKeys {
+		panic(fmt.Sprintf("Tried to access child_num %d > num_keys %d", index, n.NumKeys))
+	}
+	if index == n.NumKeys {
+		return n.RightChild
+	}
+	return n.Cells[index].Child
+}
+
+// SetChild sets the child page number at the given index
+func (n *InternalNode) SetChild(index uint32, pageNum uint32) {
+	if index > n.NumKeys {
+		panic(fmt.Sprintf("Tried to set child_num %d > num_keys %d", index, n.NumKeys))
+	}
+	if index == n.NumKeys {
+		n.RightChild = pageNum
 	} else {
-		panic("Unknown node type")
+		n.Cells[index].Child = pageNum
 	}
 }
 
-func initializeInternalNode(node []byte) {
-	*nodeType(node) = NodeTypeInternal
-	setNodeRoot(node, false)
-	*internalNodeNumKeys(node) = 0
-}
-
-func nodeParent(node []byte) *uint32 {
-	return (*uint32)(unsafe.Pointer(&node[ParentPointerOffset]))
-}
-
-func updateInternalNodeKey(node []byte, oldKey uint32, newKey uint32) {
-	oldChildIndex := internalNodeFindChild(node, oldKey)
-	*internalNodeKey(node, oldChildIndex) = newKey
-}
-
-// internalNodeFindChildByPage returns the index of the child with the given page number.
-// Returns numKeys if the child is the right child.
-// Panics if the child is not found.
-func internalNodeFindChildByPage(node []byte, childPageNum uint32) uint32 {
-	numKeys := *internalNodeNumKeys(node)
-	for i := uint32(0); i < numKeys; i++ {
-		if *internalNodeChild(node, i) == childPageNum {
+// FindChildByPage returns the index of the child with the given page number
+func (n *InternalNode) FindChildByPage(childPageNum uint32) uint32 {
+	for i := uint32(0); i < n.NumKeys; i++ {
+		if n.Cells[i].Child == childPageNum {
 			return i
 		}
 	}
-	if *internalNodeRightChild(node) == childPageNum {
-		return numKeys
+	if n.RightChild == childPageNum {
+		return n.NumKeys
 	}
 	panic("child not found in parent")
 }
 
-// internalNodeChildPtr returns a pointer to the child page number at the given cell index.
-// Unlike internalNodeChild which handles the right child case specially,
-// this returns the raw pointer to the child field in the cell.
-func internalNodeChildPtr(node []byte, cellNum uint32) *uint32 {
-	cell := internalNodeCell(node, cellNum)
-	return (*uint32)(unsafe.Pointer(&cell[0]))
+// Utility functions for working with pages
+
+// GetNodeTypeFromPage returns the node type from a raw page
+func GetNodeTypeFromPage(page []byte) NodeType {
+	return NodeType(page[0])
+}
+
+// DeserializeLeafNode creates a LeafNode from a page
+func DeserializeLeafNode(page []byte) (*LeafNode, error) {
+	node := &LeafNode{}
+	if err := node.Deserialize(page); err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+// DeserializeInternalNode creates an InternalNode from a page
+func DeserializeInternalNode(page []byte) (*InternalNode, error) {
+	node := &InternalNode{}
+	if err := node.Deserialize(page); err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+// SerializeRow converts a Row struct to bytes
+func SerializeRow(row *Row, dest []byte) {
+	binary.LittleEndian.PutUint32(dest[0:4], uint32(row.ID))
+	copy(dest[4:4+ColumnUsernameSize], row.Username[:])
+	copy(dest[4+ColumnUsernameSize:4+ColumnUsernameSize+ColumnEmailSize], row.Email[:])
+}
+
+// DeserializeRow converts bytes back to a Row struct
+func DeserializeRow(src []byte, row *Row) {
+	row.ID = int32(binary.LittleEndian.Uint32(src[0:4]))
+	copy(row.Username[:], src[4:4+ColumnUsernameSize])
+	copy(row.Email[:], src[4+ColumnUsernameSize:4+ColumnUsernameSize+ColumnEmailSize])
+}
+
+// GetMaxKeyFromPage returns the max key from a page (works for both leaf and internal)
+func GetMaxKeyFromPage(page []byte) (uint32, error) {
+	nodeType := GetNodeTypeFromPage(page)
+	switch nodeType {
+	case NodeTypeLeaf:
+		node, err := DeserializeLeafNode(page)
+		if err != nil {
+			return 0, err
+		}
+		return node.GetMaxKey(), nil
+	case NodeTypeInternal:
+		node, err := DeserializeInternalNode(page)
+		if err != nil {
+			return 0, err
+		}
+		return node.GetMaxKey(), nil
+	default:
+		return 0, fmt.Errorf("unknown node type: %d", nodeType)
+	}
+}
+
+// For backward compatibility with existing code, expose constants with old names
+const (
+	CommonHeaderSize = 6 // NodeType(1) + IsRoot(1) + Parent(4)
+)
+
+// WriteNodeToPage serializes a node (either LeafNode or InternalNode) to the provided writer
+func WriteNodeToPage(w io.Writer, node interface{}) error {
+	return binary.Write(w, binary.LittleEndian, node)
 }


### PR DESCRIPTION
  - Refactors B-Tree storage from unsafe pointer arithmetic to type-safe Go structs
  - Uses `encoding/binary` for node serialization instead of manual byte offset calculations
  - Removes all `unsafe` package usage